### PR TITLE
Changed docsRepositoryBase to documentation repo

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -66,7 +66,7 @@ const themeConfig: DocsThemeConfig = {
   chat: {
     link: "https://discord.postiz.com",
   },
-  docsRepositoryBase: "https://github.com/gitroomhq/postiz-app",
+  docsRepositoryBase: "https://github.com/gitroomhq/postiz-docs",
   footer: {
     text: "Gitroom Limited. All rights reserved.",
   },

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -66,7 +66,7 @@ const themeConfig: DocsThemeConfig = {
   chat: {
     link: "https://discord.postiz.com",
   },
-  docsRepositoryBase: "https://github.com/gitroomhq/postiz-docs",
+  docsRepositoryBase: "https://github.com/gitroomhq/postiz-docs/blob/main",
   footer: {
     text: "Gitroom Limited. All rights reserved.",
   },


### PR DESCRIPTION
Sidebar of the documentation points to non-existent pages ("Edit this page points to").

![image](https://github.com/user-attachments/assets/8b1c44ab-3fc1-4689-a774-fe71f2e8cca5)

As follows:
![image](https://github.com/user-attachments/assets/74302f42-df7a-47d4-bee3-2917d94176f2)

If I am not mistaken this is the value that has to be changed in order to fix this issue.