### PR TITLE
Removing old Email Configuration route

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -5,6 +5,5 @@
   "installation": "Installation",
   "configuration": "Configuration",
   "providers": "Providers Configuration",
-  "emails": "Email Configuration",
   "support": "Support"
 }


### PR DESCRIPTION
As per discussion with @jamesread the current left sidebar is throwing a 404 error when "Email Configuration" is clicked.

Sidebar:
![image](https://github.com/user-attachments/assets/3fad5f4d-0c98-4994-af59-4b3b5efd08e3)

Error:
![image](https://github.com/user-attachments/assets/dbf14d2c-b42b-40f5-bfb2-cdb16821f1c7)

This apparently should solve the issue.