### PR TITLE
Drafted YouTube Provider Documentation

### DIFF
--- a/pages/providers/youtube.mdx
+++ b/pages/providers/youtube.mdx
@@ -1,0 +1,40 @@
+---
+title: YouTube
+description: How to add YouTube to your system
+---
+
+import {Steps, Callout} from "nextra/components";
+
+<Callout>
+This integration requires that you have a Google account.
+</Callout>
+
+Follow the instructions as availabe in the [Obtaining authorization credentials](https://developers.google.com/youtube/registering_an_application).
+
+<Steps>
+
+### Step 1
+Make sure you are logged in to your Google account and visit the [Credentials - APIs & Services](https://console.cloud.google.com/projectselector2/apis/credentials) page. Make sure to read the terms and conditions and "Agree and Continue".
+
+### Step 2
+Create a new project by clicking on the "Create Project" button.
+
+### Step 3
+Fill in the project name, and details and click "Create".
+
+### Step 4
+Create credentials by clicking on the "Create Credentials" button. Select the "OAuth client ID" option.
+
+### Step 5
+Make sure that your consent screen has been configured. Add yourself as a test user of the application.
+
+### Step 6
+Create the OAuth client ID. Select "Web application" as the application type and fill in the details.
+</Steps>
+
+After following all of the steps above you should be met with a screen that shows your client ID and client secret. Add these to your providers configuration.
+
+```env
+YOUTUBE_CLIENT_ID=""
+YOUTUBE_CLIENT_SECRET=""
+```


### PR DESCRIPTION
As per the: https://github.com/gitroomhq/postiz-docs/issues/9 issue.

This is a draft of the YouTube provider configuration.
The config in itself requires for the user to set up an OAuth consent screen with additional details.
Additionally, it seems to me like the user needs to add oneself as the test user for self-hosted solution.

