### PR TITLE
Fix: Instagram and Facebook mdx

### DIFF
--- a/pages/providers/facebook.mdx
+++ b/pages/providers/facebook.mdx
@@ -11,7 +11,7 @@ import {Steps, Callout} from "nextra/components";
 
 <Steps>
 ### Step 1
-Create a [new app in facebook developers](https://developers.facebook.com/apps/creation/), choose the business you want to connect it to.<br />
+Create a [new app in Facebook developers](https://developers.facebook.com/apps/creation/), choose the business you want to connect it to.<br />
 Please be advised that for public applications you would need to verify you business.
 
 ![Create app](https://github.com/user-attachments/assets/e24f15a7-d9b1-48cb-8952-7a5258923b4c)

--- a/pages/providers/instagram.mdx
+++ b/pages/providers/instagram.mdx
@@ -1,6 +1,6 @@
 ---
 title: Instagram
-description: How to add Facebook to your system
+description: How to add Instagram to your system
 ---
 
 import {Steps, Callout} from "nextra/components";
@@ -11,7 +11,7 @@ import {Steps, Callout} from "nextra/components";
 
 <Steps>
 ### Step 1
-Create a [new app in facebook developers](https://developers.facebook.com/apps/creation/), choose the business you want to connect it to.<br />
+Create a [new app in Instagram developers](https://developers.instagram.com/apps/creation/), choose the business you want to connect it to.<br />
 Please be advised that for public applications you would need to verify you business.
 
 ![Create app](https://github.com/user-attachments/assets/e24f15a7-d9b1-48cb-8952-7a5258923b4c)
@@ -34,7 +34,7 @@ Add all your details and click Create App
 Set final details
 
 ### Step 5
-![Setup Login with Facebook](https://github.com/user-attachments/assets/08d3c1d1-d498-49d1-adac-aa6248e7c10c)
+![Setup Login with Instagram](https://github.com/user-attachments/assets/08d3c1d1-d498-49d1-adac-aa6248e7c10c)
 
 Set up login for business
 
@@ -62,8 +62,8 @@ Go to advanced permission and request access for the following scopes:
 Go to basic permissions copy your App ID and App Secret and paste them in your `.env` file
 
 ```env
-FACEBOOK_APP_ID="app id"
-FACEBOOK_APP_SECRET="app secret"
+INSTAGRAM_APP_ID="app id"
+INSTAGRAM_APP_SECRET="app secret"
 ```
 
 Instagram should now be working!


### PR DESCRIPTION
This PR set up instructions for Instagram and Facebook on the Facebook page.

While it's recommended that Instagram and Facebook use the same app (meaning there's no need to create two separate apps), 
having dedicated instructions makes it clearer for anyone who wants to focus on either Instagram or Facebook.