### PR TITLE
Update Cloudflare R2 Bucket Documentation

### DIFF
--- a/pages/configuration/r2.mdx
+++ b/pages/configuration/r2.mdx
@@ -25,6 +25,18 @@ Create a new Bucket.
 
 <img src="https://github.com/user-attachments/assets/f679ff9f-1a9c-4d09-b663-2fa2baadea93" />
 
+Create your R2 Token by clicking "Manage R2 API Tokens"
+
+<img src="https://github.com/user-attachments/assets/f47e0b90-834f-4c18-abe0-a89b62ca6458" />
+
+Under "Permissions" choose "Object Read & Write" and under "Specify bucket(s)" search for your created Bucket.
+
+<img src="https://github.com/user-attachments/assets/30991d43-9920-47d4-9c53-bde619974009" />
+
+After the R2 Token was created, copy your "Access Key ID" and "Secret Access Key"
+
+<img src="https://github.com/user-attachments/assets/d4b4218f-fe20-47ec-937a-0d516fa74c64" />
+
 Copy the information respectfully into your .env environment.
 
 ```dotenv


### PR DESCRIPTION
Added some more Documentation for working with R2 Buckets to make the User Workflow easier. 

As Cloudflare has different API keys for everything, user could get confused and try to use their actual Account API keys instead of the R2 specific once.
