### PR TITLE
Corrected spelling mistake in nginx.mdx

### DIFF
--- a/pages/reverse-proxies/nginx.mdx
+++ b/pages/reverse-proxies/nginx.mdx
@@ -214,7 +214,7 @@ sudo nginx -t
 ```
 ### Automatic reload Nginx when SSL Certificates are renewed:
 ```bash
-echo -e '#!/bin/bash\nnginx -t && systemctl reload nginx' | sudo tee /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh && sudo chmod a+x /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh
+echo -e '#!/bin/bash\nginx -t && systemctl reload nginx' | sudo tee /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh && sudo chmod a+x /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh
 ```
 ### Reload Nginx
 ```bash


### PR DESCRIPTION
Corrected a spelling mistake from nnginx to nginx in the line:

echo -e '#!/bin/bash\nnginx -t && systemctl reload nginx' | sudo tee /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh && sudo chmod a+x /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation  
  - Refined the example script for automatically reloading the web server after SSL certificate renewal, enhancing clarity and formatting without changing its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->