### PR TITLE
Increase Nginx maximum post size

### DIFF
--- a/pages/reverse-proxies/nginx.mdx
+++ b/pages/reverse-proxies/nginx.mdx
@@ -145,6 +145,9 @@ Copy your config from here:
         # Disable directory listing for security
         autoindex off;
 
+        # Increase maximum post size to prevent 413 error with images larger than 2MB (changes max size to 100MB)
+        client_max_body_size 100M;
+
         # Enable Gzip compression for better performance
         gzip on;
         gzip_comp_level 6;


### PR DESCRIPTION
Current Nginx config file will result in a 413 error ("Payload Too Large") if uploading file larger than 2MB. This change increases this to 100MB to avoid this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Increased the server’s file upload limit to 100MB, resolving issues that caused errors during larger image uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->