### PR TITLE
Update facebook.mdx

### DIFF
--- a/pages/providers/facebook.mdx
+++ b/pages/providers/facebook.mdx
@@ -56,7 +56,12 @@ Go to advanced permission and request access for the following scopes:
 `pages_read_engagement`
 `read_insights`
 
+Note that if your Postiz install is for personal use only these advanced permissions are not required for Postiz to function.
+
 ### Step 8
+Change the App Mode from 'Development' to 'Live'. If you do not do this then posts made via the API will display for yourself but will not be visible for other users.
+
+### Step 9
 ![Keys](https://github.com/user-attachments/assets/ac11f87f-4951-47f8-8344-7fbc9de942e4)
 
 Go to basic permissions copy your App ID and App Secret and paste them in your `.env` file

--- a/pages/providers/facebook.mdx
+++ b/pages/providers/facebook.mdx
@@ -56,7 +56,7 @@ Go to advanced permission and request access for the following scopes:
 `pages_read_engagement`
 `read_insights`
 
-Note that if your Postiz install is for personal use only these advanced permissions are not required for Postiz to function.
+Note: If your Postiz install is for personal use only these advanced permissions are not required for Postiz to function.
 
 ### Step 8
 Change the App Mode from 'Development' to 'Live'. If you do not do this then posts made via the API will display for yourself but will not be visible for other users.


### PR DESCRIPTION
Added importance of changing App Mode to Live - doesn't work otherwise (although appears to be functioning) Added comment about advanced permissions not being required for personal use only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Facebook integration instructions.
  - Clarified that advanced permissions are unnecessary for personal installations.
  - Added a step to switch the App Mode from "Development" to "Live" to ensure posts are publicly visible.
  - Included guidance for copying the Facebook App credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->