### PR TITLE
fix auth redirect url updating oauth2redirect.tsx

### DIFF
--- a/components/snippets/oauth2redirect.tsx
+++ b/components/snippets/oauth2redirect.tsx
@@ -16,6 +16,7 @@ export default function OAuth2Redirect({
 	<ul className = "[:is(ol,ul)_&]:_my-3 [&:not(:first-child)]:_mt-6 _list-disc ltr:_ml-6 rtl:_mr-6">
 		<li>eg: If you are running on a container, and your Postiz URL is: <code className = "nextra-code">https://postiz.example.com</code>, then your OAuth2 Redirect URI is <code className = "nextra-code">https://postiz.example.com/integrations/social/{provider}</code></li>
 		<li>eg: If you are running on localhost, and your Postiz URL is <code className = "nextra-code">http://localhost:4200</code>, then your OAuth2 Redirect URI is <code className = "nextra-code">http://localhost:4200/integrations/social/{provider}</code></li>
+		<li>eg: If you are running on localhost, and the provider doesn't accept http uris, and your Postiz URL is <code className = "nextra-code">http://localhost:4200</code>, then your OAuth2 Redirect URI is <code className = "nextra-code">https://redirectmeto.com/http://localhost:4200/integrations/social/{provider}</code></li>
 	</ul>
 
 	<br />


### PR DESCRIPTION
Some providers does not accept http as redirect uri (facebook and instagram for example)
`
![image](https://github.com/user-attachments/assets/dae216c9-6613-4ec9-a6c1-f1aaf37de325)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced redirect guidance with a new example that clarifies how to structure OAuth2 Redirect URIs for localhost setups when HTTP URIs are not accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->