### PR TITLE
Update public-api.mdx

### DIFF
--- a/pages/public-api.mdx
+++ b/pages/public-api.mdx
@@ -157,13 +157,128 @@ Payload:
   ]
 }
 ```
+### Request
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| type | `draft` \| `schedule` \| `now` | Yes | Type of post creation |
+| order | string | No | Order of posts |
+| shortLink | boolean | Yes | Whether to use short link |
+| inter | number | No | Interval |
+| date | string (Date) | Yes | Date of post |
+| tags | Tags[] | Yes | Array of tags |
+| posts | Post[] | Yes (if type !== 'draft') | Array of posts |
+
+### Posts
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| integration | Integration | Yes | Integration details |
+| value | PostContent[] | Yes | Array of post content |
+| group | string | No | Group name |
+| settings | AllProvidersSettings | No | Settings for providers |
+
+### Post Value
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| content | string | Yes | Post content |
+| id | string | No | Post ID |
+| image | MediaDto[] | No | Array of media |
+
+### Integration
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| id | string | Yes | Integration ID |
+
+### Tags
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| value | string | Yes | Tag value |
+| label | string | Yes | Tag label |
+
+### Settings
+| Provider | Type | Required | Description |
+| --- | --- | --- | --- |
+| devto | DevToSettingsDto | No | Dev.to settings |
+| medium | MediumSettingsDto | No | Medium settings |
+| hashnode | HashnodeSettingsDto | No | Hashnode settings |
+| reddit | RedditSettingsDto | No | Reddit settings |
+| lemmy | LemmySettingsDto | No | Lemmy settings |
+| youtube | YoutubeSettingsDto | No | Youtube settings |
+| pinterest | PinterestSettingsDto | No | Pinterest settings |
+| dribbble | DribbbleDto | No | Dribbble settings |
+| tiktok | TikTokDto | No | TikTok settings |
+| discord | DiscordDto | No | Discord settings |
+| slack | SlackDto | No | Slack settings |
+
+### DevToSettingsDto
+| Property     | Type                                   | Description                                                                                                                                                                                             | Required |
+|--------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `title`      | `string`                               | The title of the Dev.to post.                                                                                                                                                                            | Yes      |
+| `main_image` | `MediaDto`                             | Optional main image for the Dev.to post. Refers to the `MediaDto` type.                                                                                                                                 | No       |
+| `canonical`  | `string` (URL)                         | Optional canonical URL for the Dev.to post.                                                                                                                                                             | No       |
+| `organization`| `string`                               | Optional organization associated with the post.                                                                                                                                                         | No       |
+| `tags`       | `DevToTagsSettingsDto[]` (Array of up to 4) | Optional array of tags for the Dev.to post. Each item in the array is of type `DevToTagsSettingsDto`. The array can have a maximum of 4 items. | No       |
+
+### MediumSettingsDto
+| Property     | Type                         | Description                                                                                                                                                                                             | Required |
+|--------------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `title`      | `string`                     | The title of the Medium post.                                                                                                                                                                           | Yes      |
+| `subtitle`   | `string`                     | The subtitle of the Medium post.                                                                                                                                                                        | Yes      |
+| `canonical`  | `string` (URL)               | Optional canonical URL for the Medium post.                                                                                                                                                            | No       |
+| `publication`| `string`                     | Optional publication associated with the post.                                                                                                                                                        | No       |
+| `tags`       | `MediumTagsSettings[]` (Array of up to 4) | Optional array of tags for the Medium post. Each item in the array is of type `MediumTagsSettings`. The array can have a maximum of 4 items. | No       |
+
+### HashnodeSettingsDto
+| Property     | Type                          | Description                                                                                                                                                                                                 | Required |
+|--------------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `title`      | `string`                      | The title of the Hashnode post.                                                                                                                                                                             | Yes      |
+| `subtitle`   | `string`                      | The optional subtitle of the Hashnode post.                                                                                                                                                                 | No       |
+| `main_image` | `MediaDto`                    | Optional main image for the Hashnode post. Refers to the `MediaDto` type.                                                                                                                                     | No       |
+| `canonical`  | `string` (URL)                | Optional canonical URL for the Hashnode post.                                                                                                                                                             | No       |
+| `publication`| `string`                      | The slug of the Hashnode publication to post to.                                                                                                                                                            | Yes      |
+| `tags`       | `HashnodeTagsSettings[]` (Array with at least 1 item) | An array of tags for the Hashnode post. Each item in the array is of type `HashnodeTagsSettings`. The array must contain at least one tag. | Yes      |
+
+
+curl:
+```
+curl -X POST \
+  https://POSTIZ_URL/public/v1/posts \
+  -H 'Authorization: API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "type": "draft",
+  "order": "",
+  "shortLink": true,
+  "inter": 0,
+  "date": "2025-05-07T12:00:00.000Z",
+  "tags": [
+    {
+      "value": "",
+      "label": ""
+    }
+  ],
+  "posts": [
+    {
+      "integration": {
+        "id": "INTEGRATION_ID"
+      },
+      "value": [
+        {
+          "content": "content",
+          "id": "",
+          "image": []
+        }
+      ],
+      "group": "",
+      "settings": {}
+    }
+  ]
+}'
+```
 
 Response:
 
 ```json
-{
-  "id": "e639003b-f727-4a1e-87bd-74a2c48ae41e"
-}
+[{"postId":"POST_ID","integration":"INTEGRATION_ID"}]
 ```
 
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation for the `POST /public/v1/posts` API endpoint with detailed schema tables for request payloads and provider-specific settings.
  - Added a complete example `curl` command for making requests.
  - Updated the response example to show an array of objects with `postId` and `integration` fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->