### PR TITLE
fix(oidc): don't warning about / not needed on latest tag 1.43.2

### DIFF
--- a/pages/configuration/oauth.mdx
+++ b/pages/configuration/oauth.mdx
@@ -6,12 +6,8 @@ description: How to configure OIDC
 import { Steps, Callout } from "nextra/components";
 
 <Callout type="warning">
-  **Warning:** With the actual implementation of the OIDC provider, GitHub / Google login
-  provider will be disabled.
-</Callout>
-
-<Callout type="warning">
-  **Warning:** Do not use any trailing slashes ("/") at the end of any OIDC Variables.
+  **Warning:** With the actual implementation of the OIDC provider, GitHub /
+  Google login provider will be disabled.
 </Callout>
 
 If you want to use OAuth/OIDC, please follow the instructions below.


### PR DESCRIPTION
Related : https://github.com/gitroomhq/postiz-app/pull/736 https://github.com/gitroomhq/postiz-app/discussions/734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed a duplicate warning about trailing slashes in OIDC variables from the OIDC configuration documentation.
  - Reformatted the remaining warning for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->