### PR TITLE
Fix Mastodon provider docs typo and include new info about using a custom Mastodon instance

### DIFF
--- a/pages/providers/mastodon.mdx
+++ b/pages/providers/mastodon.mdx
@@ -35,7 +35,7 @@ This will give you output that looks something like this;
   "redirect_uris": [
     "http://localhost:4200/integrations/social/mastodon"
   ],
-...
+  ...
   "client_id": "your_client_id",
   "client_secret": "your_client_secret"
 }

--- a/pages/providers/mastodon.mdx
+++ b/pages/providers/mastodon.mdx
@@ -7,15 +7,19 @@ import {Steps, Callout} from "nextra/components";
 import OAuth2Redirect from "../../components/snippets/oauth2redirect.tsx";
 
 <Callout>
-Watch the YouTube Tutorial: 
+Watch the YouTube Tutorial:
 https://youtu.be/IAnfbE_htqg?si=z30m5qS8qLDN9R0X
 </Callout>
 
-Mastodon client registration is not done via ther web interface, but by talking to the API directly. In the example below, we use `curl` to register a new client.
+Mastodon client registration is not done via the web interface, but by talking to the API directly. In the example below, we use `curl` to register a new client.
 
 Optionally check that you have `jq` installed on your system. You can normally install this with brew, apt-get, yum or chocolatey. If you don't have `jq` installed, you can remove it from the command below.
 
 <OAuth2Redirect provider = "mastodon" />
+
+<Callout type="info">
+The examples on this page use `https://mastodon.social` as the default Mastodon instance. If you are setting up Postiz to connect to a different self-hosted Mastodon instance (e.g., `https://fosstodon.org`), you must replace `https://mastodon.social` with your instance's URL in the `curl` command below. You will also need to ensure the `MASTODON_URL` environment variable in your application's `.env` file (or equivalent configuration for Docker, etc.) is set to your custom instance's URL.
+</Callout>
 
 Run the following curl command in a terminal to get the Mastodon client id and client secret.
 
@@ -31,7 +35,7 @@ This will give you output that looks something like this;
   "redirect_uris": [
     "http://localhost:4200/integrations/social/mastodon"
   ],
-  ...
+...
   "client_id": "your_client_id",
   "client_secret": "your_client_secret"
 }
@@ -42,6 +46,7 @@ Make a note of your `client_id` and `client_secret` and add them to your `.env` 
 ```env
 MASTODON_CLIENT_ID="shown in the output from the above command"
 MASTODON_CLIENT_SECRET="shown in the output from the above command"
+MASTODON_URL="https://mastodon.social" # Change this if connecting to a different instance
 ```
 
 Stop Postiz if it is running, and then start it using the .env file with the Mastodon details. Click through the new channel setup and you should be asked to login on Mastodon.


### PR DESCRIPTION
^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for configuring the Mastodon instance URL when connecting to self-hosted or alternative servers.
  - Added an informational callout about updating example commands and environment variables.
  - Fixed a minor typo in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->