### PR TITLE
Add a notice for Meta requirements on screencasts

### DIFF
--- a/pages/providers/facebook.mdx
+++ b/pages/providers/facebook.mdx
@@ -16,7 +16,13 @@ import NeverShare from "../../components/snippets/never.share.mdx";
 <Steps>
 ### Step 1
 Select a business portfolio, then create a [new app in Facebook developers](https://developers.facebook.com/apps/creation/).<br />
-Please be advised that for public applications, you will need to verify your business.
+Please be advised that for public applications, you will need to verify your business,
+and [submit a screencast](https://developers.facebook.com/docs/resp-plat-initiatives/individual-processes/app-review/submission-guide)
+showing log-in to your app, connecting an actual Facebook account,
+clicking the during-connect link to privacy policy, posting something with a comment,
+showing that it actually appears in the feed, and showing the Postiz analytics.
+It can be one long video for all three (Facebook, Instagram (Facebook Business) and Instagram (standalone)) flows.
+Expect many LLM-generated roundtrips with the review team.
 
 ![Business Portfolio](/images/providers/facebook/Business-Portfolio.png)
 

--- a/pages/providers/instagram.mdx
+++ b/pages/providers/instagram.mdx
@@ -23,7 +23,14 @@ The following steps will guide you through the setup of a Meta application that 
 <Steps>
 ### Step 1
 Select a business portfolio, then create a [new app in Meta for developers](https://developers.facebook.com/apps/creation/).<br />
-Please be advised that for public applications, you will need to verify your business.
+Please be advised that for public applications, you will need to verify your business,
+and [submit a screencast](https://developers.facebook.com/docs/resp-plat-initiatives/individual-processes/app-review/submission-guide)
+showing log-in to your app, connecting an actual Instagram account,
+clicking the during-connect link to privacy policy, posting something with a comment,
+showing that it actually appears in the feed, and showing the Postiz analytics.
+It can be one long video for all three (Facebook, Instagram (Facebook Business) and Instagram (standalone)) flows.
+Expect many LLM-generated roundtrips with the review team,
+who might not be very helpful understanding the distinction between the two Instagram flows.
 
 ![Business Portfolio](/images/providers/facebook/Business-Portfolio.png)
 
@@ -156,3 +163,11 @@ Go to your Instagram account, and accept the tester invitation in the [Apps and 
 
 </Steps>
 
+### Setting up permissions
+
+If you want to be able to access any Instagram account without adding them as Instagram Testers,
+go to advanced permission (just like the Facebook Business variant) and request access for the following scopes:
+`instagram_business_basic`
+`instagram_business_content_publish`
+`instagram_business_manage_comments`
+`instagram_business_manage_insights`


### PR DESCRIPTION
This is a minor warning for the curious admin trying to add a more seamless login experience for users.
Do you think this description is worthwhile to include?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Facebook and Instagram provider setup guides with detailed requirements for public applications, including screencast submission steps and review process expectations.
  * Added a new section to the Instagram setup guide outlining required advanced permissions and scopes for accessing any Instagram account without adding testers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->