### PR TITLE
docs(titkok): clarify media posting requirements

### DIFF
--- a/pages/providers/tiktok.mdx
+++ b/pages/providers/tiktok.mdx
@@ -8,11 +8,13 @@ import OAuth2Redirect from "../../components/snippets/oauth2redirect.tsx";
 import NeverShare from "../../components/snippets/never.share.mdx";
 
 <NeverShare />
+
 <Callout>
 This integration requires that you have a TikTok developer account. It also requires that you have a public website, with https, and can upload files to that site to verify ownership.
 
 TikTok will also not allow http:// for your app redirect URI, so you will need to be accessing Postiz from HTTPS.
 </Callout>
+
 <Callout type="warning">
 **NOTE:** Due to TikTok's restrictions, to upload media you have to host Postiz on a domain using a reverse proxy such as [Caddy](/reverse-proxies/caddy/) or an more manual setup with [Cloudflare R2](/configuration/r2/).
 

--- a/pages/providers/tiktok.mdx
+++ b/pages/providers/tiktok.mdx
@@ -16,9 +16,10 @@ TikTok will also not allow http:// for your app redirect URI, so you will need t
 </Callout>
 
 <Callout type="warning">
-**NOTE:** Due to TikTok's restrictions, to upload media you have to host Postiz on a domain using a reverse proxy such as [Caddy](/reverse-proxies/caddy/) or an more manual setup with [Cloudflare R2](/configuration/r2/).
+**NOTE:** TikTok fetches media via pull_from_url. Your media files must be publicly reachable over HTTPS; localhost or private routes (e.g., /uploads) will fail. 
+Expose your uploads via a reverse proxy (e.g., [Caddy](/reverse-proxies/caddy/)) or use object storage/CDN such as [Cloudflare R2](/configuration/r2/) with public access.
 
-Make sure the domain you host media on is on your developer account's list of sites with verified ownership.
+Ensure the media domain is listed under your TikTok developer account’s verified sites.
 </Callout>
 
 <Steps>

--- a/pages/providers/tiktok.mdx
+++ b/pages/providers/tiktok.mdx
@@ -8,11 +8,15 @@ import OAuth2Redirect from "../../components/snippets/oauth2redirect.tsx";
 import NeverShare from "../../components/snippets/never.share.mdx";
 
 <NeverShare />
-
 <Callout>
 This integration requires that you have a TikTok developer account. It also requires that you have a public website, with https, and can upload files to that site to verify ownership.
 
 TikTok will also not allow http:// for your app redirect URI, so you will need to be accessing Postiz from HTTPS.
+</Callout>
+<Callout type="warning">
+**NOTE:** Due to TikTok's restrictions, to upload media you have to host Postiz on a domain using a reverse proxy such as [Caddy](/reverse-proxies/caddy/) or an more manual setup with [Cloudflare R2](/configuration/r2/).
+
+Make sure the domain you host media on is on your developer account's list of sites with verified ownership.
 </Callout>
 
 <Steps>


### PR DESCRIPTION
Currently, Postiz only uses [pull_from_url](https://developers.tiktok.com/doc/content-posting-api-media-transfer-guide/#pull_from_url) for TikTok content uploading: [here](https://github.com/gitroomhq/postiz-app/blob/main/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts).

If you are hosting your uploaded media on your localhost, or just haven't publicly exposed your `/uploads` route, TikTok will not be able to access your file. 

There is a viable alternative, [work with chunks](https://developers.tiktok.com/doc/content-posting-api-media-transfer-guide/#work_with_chunks) which would take a little bit of work but would bypass the need to publicly expose your `/uploads`. 

Anyways, this pull request clarifies the docs with the message:

> **NOTE:** Due to TikTok's restrictions, to upload media you have to host Postiz on a domain using a reverse proxy such as [Caddy](/reverse-proxies/caddy/) or an more manual setup with [Cloudflare R2](/configuration/r2/). 
> Make sure the domain you host media on is on your developer account's list of sites with verified ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prominent warning in the TikTok provider docs: media must be publicly reachable over HTTPS (localhost/private routes will fail). Includes guidance to host uploads via a reverse proxy or object storage/CDN (e.g., Cloudflare R2) and to verify the media domain in your TikTok developer account to prevent blocked media during uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->