### PR TITLE
Add trailing slashes to Authentik URLs in docker-compose docs

### DIFF
--- a/pages/installation/docker-compose.mdx
+++ b/pages/installation/docker-compose.mdx
@@ -143,9 +143,9 @@ services:
       NEXT_PUBLIC_POSTIZ_OAUTH_LOGO_URL: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/master/png/authentik.png"
       POSTIZ_GENERIC_OAUTH: "false"
       POSTIZ_OAUTH_URL: "https://auth.example.com"
-      POSTIZ_OAUTH_AUTH_URL: "https://auth.example.com/application/o/authorize"
-      POSTIZ_OAUTH_TOKEN_URL: "https://auth.example.com/application/o/token"
-      POSTIZ_OAUTH_USERINFO_URL: "https://authentik.example.com/application/o/userinfo"
+      POSTIZ_OAUTH_AUTH_URL: "https://auth.example.com/application/o/authorize/"
+      POSTIZ_OAUTH_TOKEN_URL: "https://auth.example.com/application/o/token/"
+      POSTIZ_OAUTH_USERINFO_URL: "https://authentik.example.com/application/o/userinfo/"
       POSTIZ_OAUTH_CLIENT_ID: ""
       POSTIZ_OAUTH_CLIENT_SECRET: ""
       # POSTIZ_OAUTH_SCOPE: "openid profile email"  # Optional: uncomment to override default scope


### PR DESCRIPTION
Authentik uses trailing slashes in URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth environment variable configuration URLs in the installation guide to include trailing slashes for authentication endpoint, token endpoint, and user information endpoint URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->