### PR TITLE
Fix X/Twitter app type: use Native App instead of Web App

### DIFF
--- a/providers/x-twitter.mdx
+++ b/providers/x-twitter.mdx
@@ -35,8 +35,12 @@ So you are going to use the normal oAuth1 flow for that (that supports Twitter v
     ![X](/images/providers/x/x-003.png)
 
     - In the App Permission set it to `Read and Write`
-    - In the Type of App set it to `Web App, Automated App or Bot`
+    - In the Type of App set it to `Native App`
     - In the App Info set the `Callback URI / Redirect URL`
+
+    <Note>
+    You must select `Native App` for OAuth 1.0a to work correctly. Selecting `Web App, Automated App or Bot` will cause authentication to fail with error code 32.
+    </Note>
   </Step>
 
   <Step title="Configure OAuth2 Redirect URI">


### PR DESCRIPTION
## Description

The documentation previously instructed users to select "Web App, Automated App or Bot" for the X app type. This causes OAuth 1.0a authentication to fail with Twitter error code 32 ("Could not authenticate you").

## Changes

- Changed app type from `Web App, Automated App or Bot` to `Native App`
- Added a note explaining why Native App is required

## Problem

When configured as a Web App, the OAuth 1.0a flow fails when Postiz attempts to generate an auth link. Users see a generic `{"err":true}` response with no additional details.

## Solution

Selecting **Native App** enables proper OAuth 1.0a authentication, which is required for the Twitter v1 API (used for media uploads).

## Testing

Verified fix by:
1. Creating X Developer app as "Native App"
2. Configuring `X_API_KEY` and `X_API_SECRET` in Postiz
3. Successfully connecting X account through Postiz UI

This will close issue #212 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated X/Twitter OAuth setup guidance to clarify that Native App selection is required for OAuth 1.0a authentication. Added warning that selecting Web App, Automated App, or Bot may result in authentication failure (error code 32).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->