### PR TITLE
docs: add GitHub repo clone URL to self-hosting auth server setup

### DIFF
--- a/cli/authentication.mdx
+++ b/cli/authentication.mdx
@@ -81,7 +81,16 @@ CLI                        Auth Server                    Postiz
  |<-- access_token ------------|                           |
 ```
 
-### 1. Create an OAuth App in Postiz
+### 1. Clone the Repository
+
+The auth server lives in the [postiz-agent](https://github.com/gitroomhq/postiz-agent) repository:
+
+```bash
+git clone https://github.com/gitroomhq/postiz-agent.git
+cd postiz-agent/server
+```
+
+### 2. Create an OAuth App in Postiz
 
 Go to **Postiz Settings > Developer > OAuth Apps** and create a new app. Set the callback URL to:
 
@@ -89,11 +98,11 @@ Go to **Postiz Settings > Developer > OAuth Apps** and create a new app. Set the
 https://your-server-domain.com/device/callback
 ```
 
-### 2. Set Up Postgres
+### 3. Set Up Postgres
 
 Create a database. The server auto-creates the `device_requests` table on startup.
 
-### 3. Configure Environment
+### 4. Configure Environment
 
 ```bash
 export DATABASE_URL="postgresql://user:password@localhost:5432/postiz_auth"
@@ -112,10 +121,9 @@ export SERVER_URL="https://your-server-domain.com"
 | `POSTIZ_FRONTEND_URL` | No | `https://platform.postiz.com` | Postiz frontend URL for OAuth redirects |
 | `POSTIZ_API_URL` | No | `https://api.postiz.com` | Postiz API URL for token exchange |
 
-### 4. Run the Server
+### 5. Run the Server
 
 ```bash
-cd server
 pnpm install
 
 # Development
@@ -126,7 +134,7 @@ pnpm build
 pnpm start:prod
 ```
 
-### 5. Point the CLI to Your Server
+### 6. Point the CLI to Your Server
 
 ```bash
 export POSTIZ_AUTH_SERVER="https://your-server-domain.com"


### PR DESCRIPTION
## What

Adds a **"Clone the Repository"** step to the self-hosting section of `cli/authentication.mdx`, pointing readers to `https://github.com/gitroomhq/postiz-agent` with the exact `git clone` command.

## Why

The current setup section jumps straight to creating an OAuth app with no indication of where the server code lives. A first-time reader has no way to know they need to clone `postiz-agent` before following the remaining steps.

## Changes

- Added **Step 1 – Clone the Repository** with a link to `gitroomhq/postiz-agent` and the `git clone` + `cd` commands
- Renumbered existing steps: 1→2, 2→3, 3→4, 4→5, 5→6
- Removed the redundant `cd server` line from the "Run the Server" step (now covered in step 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced self-hosting setup documentation by reorganizing step-by-step instructions with clearer guidance for repository cloning and server initialization. Removed redundant command sequences and streamlined the configuration workflow to make the deployment process more accessible and easier for users to follow and implement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->