### PR TITLE
Document TikTok Direct Post audit requirement

### DIFF
--- a/providers/tiktok.mdx
+++ b/providers/tiktok.mdx
@@ -18,6 +18,12 @@ Expose your uploads via a reverse proxy (e.g., [Caddy](/reverse-proxies/caddy)) 
 Ensure the media domain is listed under your TikTok developer account's verified sites.
 </Warning>
 
+<Warning>
+TikTok approval is not the final step for Direct Post access. TikTok allows unaudited API clients to use the Direct Post API, but posts are restricted to private visibility until the API client completes TikTok's audit process for Terms of Service compliance.
+
+If your API client has not passed this audit, TikTok also limits Direct Post usage to up to 5 users posting in a 24-hour window, and those user accounts must be private at the time of posting. See TikTok's [Direct Post API developer guidelines](https://developers.tiktok.com/doc/content-sharing-guidelines#direct_post_api_-_developer_guidelines) for the current requirements.
+</Warning>
+
 <Steps>
   <Step title="Create your app">
     Go here: [https://developers.tiktok.com/apps](https://developers.tiktok.com/apps)
@@ -73,4 +79,3 @@ TIKTOK_CLIENT_SECRET=12345678901234567890123456789012
     Go to the Postiz web interface, and click on the "Add Channel" button. Select "TikTok" from the list of available channels. You should be redirected to TikTok to authorize the application.
   </Step>
 </Steps>
-


### PR DESCRIPTION
## Summary

Adds a warning to the TikTok provider setup docs explaining that TikTok approval is not the final step for Direct Post access.

Even after approval, unaudited API clients are restricted until they complete TikTok's Terms of Service compliance audit. The docs now mention the private-visibility restriction, the 5-user/24-hour limit, and link to TikTok's Direct Post API developer guidelines.

## Changes

- Added a TikTok Direct Post audit warning to `providers/tiktok.mdx`
- Linked to TikTok's official Content Sharing Guidelines

## Testing

- Docs-only change
- Reviewed MDX diff locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on TikTok approval and audit requirements for Direct Post access
  * Updated documentation to specify usage limits (5 users in 24-hour window) when audit is incomplete
  * Clarified private account requirements for Direct Post functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gitroomhq/postiz-docs/pull/222)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->