### PR TITLE
Fix architecture section anchor links

### DIFF
--- a/howitworks.mdx
+++ b/howitworks.mdx
@@ -37,7 +37,7 @@ flowchart LR;
 
 - [Temporal](#temporal) - A durable workflow engine that manages scheduling, retries, and task distribution.
 - [Redis](#redis) - Used for session state management and caching.
-- [SQL Database](#db) - Stores all the data, Postgres is typically used, but any SQL database can be used.
+- [SQL Database](#sql-database) - Stores all the data, Postgres is typically used, but any SQL database can be used.
 - [Storage](#storage) - Stores all the files, this used to be CloudFlare R2 as the default, but now it's just a local file system.
 
 ### Frontend
@@ -73,3 +73,14 @@ Temporal is a durable workflow execution engine. It provides:
 - **Workflow visibility** - A built-in UI for monitoring and debugging workflow execution.
 - **Durable state** - Workflow state is persisted, so nothing is lost if a service restarts.
 
+### Redis
+
+Redis stores short-lived application state such as sessions and cache data.
+
+### SQL Database
+
+The SQL database stores Postiz data. Postgres is typically used, but any compatible SQL database can be used.
+
+### Storage
+
+Storage keeps uploaded media and generated files. Local file storage is the default for new setups.


### PR DESCRIPTION
## Summary
- Fix the architecture list link for SQL Database so it targets the generated heading.
- Add short Redis, SQL Database, and Storage sections so the existing architecture links resolve.

## Validation
- `npx --yes markdown-link-check --quiet howitworks.mdx`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "How it works" guide with enhanced service descriptions clarifying the role of each component: Redis handles session and cache data, SQL Database stores Postiz application data, and Storage defaults to local file storage for new setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->