### PR TITLE
Update localhost URLs to use 127.0.0.1

### DIFF
--- a/providers/x-twitter.mdx
+++ b/providers/x-twitter.mdx
@@ -48,9 +48,9 @@ So you are going to use the normal oAuth1 flow for that (that supports Twitter v
 
     **Your X OAuth2 Redirect URI:**
     - Production: `https://your-postiz-domain.com/integrations/social/x`
-    - Local development: `http://localhost:4200/integrations/social/x`
-    - Docker: `http://localhost:5000/integrations/social/x`
-    - If X requires HTTPS for localhost: `https://redirectmeto.com/http://localhost:4200/integrations/social/x`
+    - Local development: `http://127.0.0.1:4200/integrations/social/x`
+    - Docker: `http://127.0.0.1:5000/integrations/social/x`
+    - If X requires HTTPS for localhost: `https://redirectmeto.com/http://127.0.0.1:4200/integrations/social/x`
   </Step>
 
   <Step title="Copy your API keys">


### PR DESCRIPTION
updated localhost URLs to 127.0.0.1 as using localhost in the url in no longer valid in the form.

Fixes #229 and possibly #168 as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated X OAuth2 Redirect URI examples to use `127.0.0.1` instead of `localhost` for local development, Docker, and HTTPS configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->