### PR TITLE
docs(tiktok): document which settings apply per posting method and media type

### DIFF
--- a/cli/media-upload.mdx
+++ b/cli/media-upload.mdx
@@ -73,3 +73,5 @@ postiz posts:create \
   --settings '{"privacy_level":"PUBLIC_TO_EVERYONE"}' \
   -i "tiktok-integration-id"
 ```
+
+`privacy_level` and the other TikTok settings apply only when `content_posting_method` is `"DIRECT_POST"` — with `"UPLOAD"` (send to the TikTok app inbox instead of publishing) TikTok keeps only the post content.

--- a/cli/media-upload.mdx
+++ b/cli/media-upload.mdx
@@ -74,4 +74,4 @@ postiz posts:create \
   -i "tiktok-integration-id"
 ```
 
-`privacy_level` and the other TikTok settings apply only when `content_posting_method` is `"DIRECT_POST"` — with `"UPLOAD"` (send to the TikTok app inbox instead of publishing) TikTok keeps only the post content.
+`privacy_level` and the other TikTok settings apply only when `content_posting_method` is `"DIRECT_POST"`, with `"UPLOAD"` (send to the TikTok app inbox instead of publishing) TikTok keeps only the post content.

--- a/cli/platform-examples.mdx
+++ b/cli/platform-examples.mdx
@@ -97,6 +97,8 @@ postiz posts:create \
   -i "tiktok-id"
 ```
 
+TikTok applies these settings only when `content_posting_method` is `"DIRECT_POST"` — with `"UPLOAD"` (send to the TikTok app inbox instead of publishing) every setting except the post content is silently discarded. `duet` and `stitch` apply to video posts only.
+
 ## Instagram
 
 ```bash

--- a/cli/platform-examples.mdx
+++ b/cli/platform-examples.mdx
@@ -97,7 +97,7 @@ postiz posts:create \
   -i "tiktok-id"
 ```
 
-TikTok applies these settings only when `content_posting_method` is `"DIRECT_POST"` — with `"UPLOAD"` (send to the TikTok app inbox instead of publishing) every setting except the post content is silently discarded. `duet` and `stitch` apply to video posts only.
+TikTok applies these settings only when `content_posting_method` is `"DIRECT_POST"`, with `"UPLOAD"` (send to the TikTok app inbox instead of publishing) every setting except the post content is silently discarded. `duet` and `stitch` apply to video posts only.
 
 ## Instagram
 

--- a/providers/tiktok.mdx
+++ b/providers/tiktok.mdx
@@ -85,3 +85,16 @@ TIKTOK_CLIENT_SECRET=12345678901234567890123456789012
     Go to the Postiz web interface, and click on the "Add Channel" button. Select "TikTok" from the list of available channels. You should be redirected to TikTok to authorize the application.
   </Step>
 </Steps>
+
+## Posting settings
+
+When composing a TikTok post, the "How do you want to post?" setting decides which other settings apply:
+
+- **Post directly to TikTok** publishes the post and applies all the settings below.
+- **Upload without posting** does **not** publish: it sends the media to the account's TikTok app inbox, where the owner must finish and publish it manually within 24 hours or it is discarded. TikTok keeps only the post content/title in this mode, so the settings panel collapses to hide the other settings while it is selected.
+
+Some settings also depend on the media type:
+
+- **Allow Duet**, **Allow Stitch**, and **Video made with AI** apply to videos only — TikTok has no equivalent for photo posts.
+- **Auto add music** applies to photos only.
+- Privacy level, comments, and the branded-content toggles apply to both videos and photos.

--- a/providers/tiktok.mdx
+++ b/providers/tiktok.mdx
@@ -95,6 +95,6 @@ When composing a TikTok post, the "How do you want to post?" setting decides whi
 
 Some settings also depend on the media type:
 
-- **Allow Duet**, **Allow Stitch**, and **Video made with AI** apply to videos only — TikTok has no equivalent for photo posts.
+- **Allow Duet**, **Allow Stitch**, and **Video made with AI** apply to videos only, TikTok has no equivalent for photo posts.
 - **Auto add music** applies to photos only.
 - Privacy level, comments, and the branded-content toggles apply to both videos and photos.

--- a/public-api/introduction.mdx
+++ b/public-api/introduction.mdx
@@ -127,7 +127,7 @@ When creating posts, each social media platform has its own settings schema. The
     | YouTube | `youtube` | `title`, `type`, `selfDeclaredMadeForKids`, `thumbnail`, `tags` |
     | TikTok | `tiktok` | `privacy_level`, `duet`, `stitch`, `comment`, `autoAddMusic`, `brand_content_toggle`, `brand_organic_toggle`, `content_posting_method` |
 
-    TikTok applies every setting except the title only when `content_posting_method` is `DIRECT_POST`; `duet`/`stitch` are video-only and `autoAddMusic` photo-only — see [TikTok settings](/public-api/providers/tiktok).
+    TikTok applies every setting except the title only when `content_posting_method` is `DIRECT_POST`; `duet`/`stitch` are video-only and `autoAddMusic` photo-only, see [TikTok settings](/public-api/providers/tiktok).
   </Tab>
   <Tab title="Community">
     | Platform | `__type` | Key settings |

--- a/public-api/introduction.mdx
+++ b/public-api/introduction.mdx
@@ -126,6 +126,8 @@ When creating posts, each social media platform has its own settings schema. The
     |----------|----------|--------------|
     | YouTube | `youtube` | `title`, `type`, `selfDeclaredMadeForKids`, `thumbnail`, `tags` |
     | TikTok | `tiktok` | `privacy_level`, `duet`, `stitch`, `comment`, `autoAddMusic`, `brand_content_toggle`, `brand_organic_toggle`, `content_posting_method` |
+
+    TikTok applies every setting except the title only when `content_posting_method` is `DIRECT_POST`; `duet`/`stitch` are video-only and `autoAddMusic` photo-only — see [TikTok settings](/public-api/providers/tiktok).
   </Tab>
   <Tab title="Community">
     | Platform | `__type` | Key settings |

--- a/public-api/openapi.json
+++ b/public-api/openapi.json
@@ -2729,7 +2729,8 @@
             "enum": [
               "DIRECT_POST",
               "UPLOAD"
-            ]
+            ],
+            "description": "Required. Use \"DIRECT_POST\" to actually publish the post to TikTok. \"UPLOAD\" does NOT publish: it only sends the media to the user's TikTok app inbox, where they must manually finish and publish it within 24 hours or it is discarded. Only use \"UPLOAD\" when the user explicitly asks to review or edit the post inside the TikTok app before publishing."
           }
         }
       },

--- a/public-api/openapi.json
+++ b/public-api/openapi.json
@@ -2688,7 +2688,8 @@
           },
           "title": {
             "type": "string",
-            "maxLength": 90
+            "maxLength": 90,
+            "description": "Used as the title of the post. The only setting TikTok keeps when content_posting_method=UPLOAD."
           },
           "privacy_level": {
             "type": "string",
@@ -2697,32 +2698,40 @@
               "MUTUAL_FOLLOW_FRIENDS",
               "FOLLOWER_OF_CREATOR",
               "SELF_ONLY"
-            ]
+            ],
+            "description": "Applied only when content_posting_method=DIRECT_POST. Ignored by TikTok on UPLOAD."
           },
           "duet": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Video posts only, and only when content_posting_method=DIRECT_POST. TikTok has no duet setting for photo posts."
           },
           "stitch": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Video posts only, and only when content_posting_method=DIRECT_POST. TikTok has no stitch setting for photo posts."
           },
           "comment": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Applied only when content_posting_method=DIRECT_POST. Ignored by TikTok on UPLOAD."
           },
           "autoAddMusic": {
             "type": "string",
             "enum": [
               "yes",
               "no"
-            ]
+            ],
+            "description": "Photo posts only, and only when content_posting_method=DIRECT_POST. Ignored by TikTok on UPLOAD."
           },
           "brand_content_toggle": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Applied only when content_posting_method=DIRECT_POST. Ignored by TikTok on UPLOAD."
           },
           "brand_organic_toggle": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Applied only when content_posting_method=DIRECT_POST. Ignored by TikTok on UPLOAD."
           },
           "video_made_with_ai": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Labels the post as AI generated. Video posts only, and only when content_posting_method=DIRECT_POST. TikTok has no AI-generated label for photo posts, and discards it on UPLOAD."
           },
           "content_posting_method": {
             "type": "string",
@@ -2730,7 +2739,7 @@
               "DIRECT_POST",
               "UPLOAD"
             ],
-            "description": "Required. Use \"DIRECT_POST\" to actually publish the post to TikTok. \"UPLOAD\" does NOT publish: it only sends the media to the user's TikTok app inbox, where they must manually finish and publish it within 24 hours or it is discarded. Only use \"UPLOAD\" when the user explicitly asks to review or edit the post inside the TikTok app before publishing."
+            "description": "Required. Use \"DIRECT_POST\" to actually publish the post to TikTok. \"UPLOAD\" does NOT publish: it only sends the media to the user's TikTok app inbox, where they must manually finish and publish it within 24 hours or it is discarded. Only use \"UPLOAD\" when the user explicitly asks to review or edit the post inside the TikTok app before publishing. \"UPLOAD\" also makes TikTok ignore every other setting in this object except the title."
           }
         }
       },

--- a/public-api/posts/create.mdx
+++ b/public-api/posts/create.mdx
@@ -57,7 +57,7 @@ When creating posts, each social media platform requires different settings. The
     | YouTube | `youtube` | `title`, `type` |
     | TikTok | `tiktok` | `privacy_level`, `duet`, `stitch`, `comment`, `autoAddMusic`, `brand_content_toggle`, `brand_organic_toggle`, `content_posting_method` |
 
-    TikTok honors these settings only when `content_posting_method` is `DIRECT_POST` — with `UPLOAD` it keeps only the post content/title. `duet`, `stitch`, and `video_made_with_ai` apply to video posts only; `autoAddMusic` to photo posts only. See [TikTok settings](/public-api/providers/tiktok).
+    TikTok honors these settings only when `content_posting_method` is `DIRECT_POST`, with `UPLOAD` it keeps only the post content/title. `duet`, `stitch`, and `video_made_with_ai` apply to video posts only; `autoAddMusic` to photo posts only. See [TikTok settings](/public-api/providers/tiktok).
   </Tab>
   <Tab title="Community Platforms">
     | Platform | `__type` | Required Settings |

--- a/public-api/posts/create.mdx
+++ b/public-api/posts/create.mdx
@@ -56,6 +56,8 @@ When creating posts, each social media platform requires different settings. The
     |----------|----------|-------------------|
     | YouTube | `youtube` | `title`, `type` |
     | TikTok | `tiktok` | `privacy_level`, `duet`, `stitch`, `comment`, `autoAddMusic`, `brand_content_toggle`, `brand_organic_toggle`, `content_posting_method` |
+
+    TikTok honors these settings only when `content_posting_method` is `DIRECT_POST` — with `UPLOAD` it keeps only the post content/title. `duet`, `stitch`, and `video_made_with_ai` apply to video posts only; `autoAddMusic` to photo posts only. See [TikTok settings](/public-api/providers/tiktok).
   </Tab>
   <Tab title="Community Platforms">
     | Platform | `__type` | Required Settings |

--- a/public-api/providers/tiktok.mdx
+++ b/public-api/providers/tiktok.mdx
@@ -39,12 +39,12 @@ When uploading a video to TikTok, use the following settings schema:
 | `brand_content_toggle` | `boolean` | Yes | Branded content disclosure. `DIRECT_POST` only |
 | `brand_organic_toggle` | `boolean` | Yes | Organic branded content. `DIRECT_POST` only |
 | `video_made_with_ai` | `boolean` | No | AI-generated content disclosure. Video posts only; `DIRECT_POST` only |
-| `content_posting_method` | `string` | Yes | Whether to publish directly or send to the TikTok app inbox — see below |
+| `content_posting_method` | `string` | Yes | Whether to publish directly or send to the TikTok app inbox, see below |
 
-**`DIRECT_POST` only** — TikTok applies the setting only when `content_posting_method` is
+**`DIRECT_POST` only**: TikTok applies the setting only when `content_posting_method` is
 `DIRECT_POST`. With `UPLOAD` the field is still required by the Postiz API, but TikTok silently
-discards it. **Video posts only** — TikTok's photo posts have no duet, stitch, or AI-generated
-label, so these settings are discarded when the post is a picture. **Photo posts only** —
+discards it. **Video posts only**: TikTok's photo posts have no duet, stitch, or AI-generated
+label, so these settings are discarded when the post is a picture. **Photo posts only**:
 `autoAddMusic` has no effect on videos.
 
 ### `privacy_level`
@@ -68,13 +68,10 @@ label, so these settings are discarded when the post is a picture. **Photo posts
 | Value | Description |
 |-------|-------------|
 | `DIRECT_POST` | Publishes the post to TikTok. **Use this unless the user explicitly wants to review the post in the TikTok app first.** |
-| `UPLOAD` | Does **not** publish. Sends the media to the account's TikTok app inbox, where the user must manually finish and publish it within 24 hours or it is discarded. TikTok keeps only the title/content in this mode — every other setting is silently discarded. |
+| `UPLOAD` | Does **not** publish. Sends the media to the account's TikTok app inbox, where the user must manually finish and publish it within 24 hours or it is discarded. TikTok keeps only the title/content in this mode, every other setting is silently discarded. |
 
 <Warning>
-A post created with `UPLOAD` is reported as **successfully published** by the Postiz API, because
-the upload to TikTok did succeed. It will not appear on the TikTok profile until the account owner
-opens the TikTok app, finds the draft in their inbox, and publishes it manually. Choose `UPLOAD`
-only when that manual step is what the user asked for.
+A post created with `UPLOAD` is reported as **successfully published** by the Postiz API, because the upload to TikTok did succeed. It will not appear on the TikTok profile until the account owner opens the TikTok app, finds the draft in their inbox, and publishes it manually. Choose `UPLOAD` only when that manual step is what the user asked for.
 </Warning>
 
 ---
@@ -183,9 +180,9 @@ only when that manual step is what the user asked for.
 ```
 
 This publishes a video that only the account owner can see. To send the media to the account's
-TikTok app inbox instead of publishing, use `content_posting_method: "UPLOAD"` — but TikTok then
+TikTok app inbox instead of publishing, use `content_posting_method: "UPLOAD"`, but TikTok then
 keeps only the title/content: every other setting above is still required by the API, yet
-silently discarded — see [`content_posting_method`](#content_posting_method) above.
+silently discarded, see [`content_posting_method`](#content_posting_method) above.
 
 <Warning>
 **Important:** TikTok requires media files to be publicly accessible via HTTPS. Local files or private URLs will fail. Use [Cloudflare R2](/configuration/r2) or similar storage with public access.

--- a/public-api/providers/tiktok.mdx
+++ b/public-api/providers/tiktok.mdx
@@ -30,16 +30,22 @@ When uploading a video to TikTok, use the following settings schema:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `__type` | `string` | Yes | Must be `tiktok` |
-| `title` | `string` | No | Video title (max 90 characters) |
-| `privacy_level` | `string` | Yes | Who can view the video |
-| `duet` | `boolean` | Yes | Allow duets |
-| `stitch` | `boolean` | Yes | Allow stitches |
-| `comment` | `boolean` | Yes | Allow comments |
-| `autoAddMusic` | `string` | Yes | Auto-add music to video |
-| `brand_content_toggle` | `boolean` | Yes | Branded content disclosure |
-| `brand_organic_toggle` | `boolean` | Yes | Organic branded content |
-| `video_made_with_ai` | `boolean` | No | AI-generated content disclosure |
+| `title` | `string` | No | Video title (max 90 characters). The only setting TikTok keeps when `content_posting_method` is `UPLOAD` |
+| `privacy_level` | `string` | Yes | Who can view the video. `DIRECT_POST` only |
+| `duet` | `boolean` | Yes | Allow duets. Video posts only; `DIRECT_POST` only |
+| `stitch` | `boolean` | Yes | Allow stitches. Video posts only; `DIRECT_POST` only |
+| `comment` | `boolean` | Yes | Allow comments. `DIRECT_POST` only |
+| `autoAddMusic` | `string` | Yes | Auto-add music. Photo posts only; `DIRECT_POST` only |
+| `brand_content_toggle` | `boolean` | Yes | Branded content disclosure. `DIRECT_POST` only |
+| `brand_organic_toggle` | `boolean` | Yes | Organic branded content. `DIRECT_POST` only |
+| `video_made_with_ai` | `boolean` | No | AI-generated content disclosure. Video posts only; `DIRECT_POST` only |
 | `content_posting_method` | `string` | Yes | Whether to publish directly or send to the TikTok app inbox — see below |
+
+**`DIRECT_POST` only** — TikTok applies the setting only when `content_posting_method` is
+`DIRECT_POST`. With `UPLOAD` the field is still required by the Postiz API, but TikTok silently
+discards it. **Video posts only** — TikTok's photo posts have no duet, stitch, or AI-generated
+label, so these settings are discarded when the post is a picture. **Photo posts only** —
+`autoAddMusic` has no effect on videos.
 
 ### `privacy_level`
 
@@ -62,7 +68,7 @@ When uploading a video to TikTok, use the following settings schema:
 | Value | Description |
 |-------|-------------|
 | `DIRECT_POST` | Publishes the post to TikTok. **Use this unless the user explicitly wants to review the post in the TikTok app first.** |
-| `UPLOAD` | Does **not** publish. Sends the media to the account's TikTok app inbox, where the user must manually finish and publish it within 24 hours or it is discarded. |
+| `UPLOAD` | Does **not** publish. Sends the media to the account's TikTok app inbox, where the user must manually finish and publish it within 24 hours or it is discarded. TikTok keeps only the title/content in this mode — every other setting is silently discarded. |
 
 <Warning>
 A post created with `UPLOAD` is reported as **successfully published** by the Postiz API, because
@@ -157,29 +163,29 @@ only when that manual step is what the user asked for.
 }
 ```
 
-### Send to TikTok App Inbox (not published)
+### Private Video (visible only to you)
 
 ```json
 {
   "settings": {
     "__type": "tiktok",
     "title": "",
-    "privacy_level": "PUBLIC_TO_EVERYONE",
+    "privacy_level": "SELF_ONLY",
     "duet": false,
     "stitch": false,
     "comment": false,
     "autoAddMusic": "no",
     "brand_content_toggle": false,
     "brand_organic_toggle": false,
-    "content_posting_method": "UPLOAD"
+    "content_posting_method": "DIRECT_POST"
   }
 }
 ```
 
-This does **not** publish. The video is delivered to the account's TikTok app inbox, where the
-owner must finish and publish it manually within 24 hours — see
-[`content_posting_method`](#content_posting_method) above. To publish a video that only you can
-see, use `privacy_level: "SELF_ONLY"` with `content_posting_method: "DIRECT_POST"`.
+This publishes a video that only the account owner can see. To send the media to the account's
+TikTok app inbox instead of publishing, use `content_posting_method: "UPLOAD"` — but TikTok then
+keeps only the title/content: every other setting above is still required by the API, yet
+silently discarded — see [`content_posting_method`](#content_posting_method) above.
 
 <Warning>
 **Important:** TikTok requires media files to be publicly accessible via HTTPS. Local files or private URLs will fail. Use [Cloudflare R2](/configuration/r2) or similar storage with public access.

--- a/public-api/providers/tiktok.mdx
+++ b/public-api/providers/tiktok.mdx
@@ -39,7 +39,7 @@ When uploading a video to TikTok, use the following settings schema:
 | `brand_content_toggle` | `boolean` | Yes | Branded content disclosure |
 | `brand_organic_toggle` | `boolean` | Yes | Organic branded content |
 | `video_made_with_ai` | `boolean` | No | AI-generated content disclosure |
-| `content_posting_method` | `string` | Yes | How to post the content |
+| `content_posting_method` | `string` | Yes | Whether to publish directly or send to the TikTok app inbox — see below |
 
 ### `privacy_level`
 
@@ -61,8 +61,15 @@ When uploading a video to TikTok, use the following settings schema:
 
 | Value | Description |
 |-------|-------------|
-| `DIRECT_POST` | Post directly to TikTok |
-| `UPLOAD` | Upload for manual posting |
+| `DIRECT_POST` | Publishes the post to TikTok. **Use this unless the user explicitly wants to review the post in the TikTok app first.** |
+| `UPLOAD` | Does **not** publish. Sends the media to the account's TikTok app inbox, where the user must manually finish and publish it within 24 hours or it is discarded. |
+
+<Warning>
+A post created with `UPLOAD` is reported as **successfully published** by the Postiz API, because
+the upload to TikTok did succeed. It will not appear on the TikTok profile until the account owner
+opens the TikTok app, finds the draft in their inbox, and publishes it manually. Choose `UPLOAD`
+only when that manual step is what the user asked for.
+</Warning>
 
 ---
 
@@ -150,14 +157,14 @@ When uploading a video to TikTok, use the following settings schema:
 }
 ```
 
-### Private Video (Draft)
+### Send to TikTok App Inbox (not published)
 
 ```json
 {
   "settings": {
     "__type": "tiktok",
     "title": "",
-    "privacy_level": "SELF_ONLY",
+    "privacy_level": "PUBLIC_TO_EVERYONE",
     "duet": false,
     "stitch": false,
     "comment": false,
@@ -168,6 +175,11 @@ When uploading a video to TikTok, use the following settings schema:
   }
 }
 ```
+
+This does **not** publish. The video is delivered to the account's TikTok app inbox, where the
+owner must finish and publish it manually within 24 hours — see
+[`content_posting_method`](#content_posting_method) above. To publish a video that only you can
+see, use `privacy_level: "SELF_ONLY"` with `content_posting_method: "DIRECT_POST"`.
 
 <Warning>
 **Important:** TikTok requires media files to be publicly accessible via HTTPS. Local files or private URLs will fail. Use [Cloudflare R2](/configuration/r2) or similar storage with public access.


### PR DESCRIPTION
## Why

A production user ticked **"Video made with AI"** on a TikTok post using the **UPLOAD** content posting method and the label was silently dropped: TikTok's [inbox upload endpoint](https://developers.tiktok.com/doc/content-posting-api-reference-upload-video/) accepts no `post_info` at all, so every Postiz setting except the title/content has nowhere to go. The app-side fix landed in gitroomhq/postiz-app#1728 (UI hides DIRECT_POST-only settings in UPLOAD mode, `TikTokDto` fields carry `@JSONSchema` descriptions, provider `@Rules` teach the agent the constraints) — this PR brings the docs in line with it.

TikTok settings vary along two axes the docs never stated:

1. **Posting method** — with `content_posting_method=UPLOAD`, TikTok keeps only the title/content; all other settings require `DIRECT_POST`. UPLOAD also never publishes: the media lands in the TikTok app inbox as a draft the user must finish within 24h, while the API still reports success.
2. **Media type** (within DIRECT_POST) — `duet`, `stitch`, `video_made_with_ai` are video-only ([photo `post_info`](https://developers.tiktok.com/doc/content-posting-api-reference-photo-post) has no such fields); `autoAddMusic` is photo-only; `privacy_level`, `comment` and the brand toggles apply to both.

## What changed

- **`public-api/providers/tiktok.mdx`** — warn that UPLOAD never publishes; annotate every settings-table row with when it applies (`DIRECT_POST` only / video-only / photo-only), with a legend noting UPLOAD-discarded fields are still required by the API. Replaced the "Private Video (Draft)" example, which paired UPLOAD with settings TikTok discards, with a real Private Video example (`SELF_ONLY` + `DIRECT_POST`); the prose explains how to target the inbox instead.
- **`public-api/openapi.json`** (hand-maintained) — per-field `description`s on `TikTokSettings` mirroring `tiktok.dto.ts` from gitroomhq/postiz-app#1728, plus the discard behavior on `content_posting_method`. Descriptions only — no field, type, or required-ness changes; validated with `JSON.parse`.
- **`providers/tiktok.mdx`** — new "Posting settings" section: the settings panel collapses in UPLOAD mode (matching the #1728 UI), and which settings are video-/photo-specific.
- **`cli/platform-examples.mdx`, `cli/media-upload.mdx`, `public-api/posts/create.mdx`, `public-api/introduction.mdx`** — one-line caveats after each TikTok example/settings table.

After this PR, no example anywhere combines UPLOAD with settings TikTok will discard (verified by grep).

Docs counterpart of gitroomhq/postiz-app#1728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how TikTok’s `DIRECT_POST` vs `UPLOAD` modes affect whether media is published and which settings are honored.
  * Documented that `UPLOAD` sends to the TikTok inbox and silently discards all settings except basic post content/title.
  * Specified video-only (`duet`, `stitch`, AI-made video) and photo-only (`auto add music`) options, plus video/photo behavior for privacy, comments, and branded-content toggles.
  * Updated examples to reflect private visibility and the `UPLOAD` workflow, including the “success” messaging caveat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->