### PR TITLE
docs: List Posts settings field + postsListTool

### DIFF
--- a/mcp/introduction.mdx
+++ b/mcp/introduction.mdx
@@ -9,7 +9,7 @@ This means you can connect Claude, ChatGPT, Cursor, or any MCP-compatible client
 
 ## How It Works
 
-Postiz exposes an MCP server that provides **9 tools** to AI agents. The agent discovers these tools, understands their schemas, and calls them on your behalf.
+Postiz exposes an MCP server that provides **10 tools** to AI agents. The agent discovers these tools, understands their schemas, and calls them on your behalf.
 
 ```mermaid
 sequenceDiagram
@@ -34,6 +34,7 @@ sequenceDiagram
 | `integrationSchema` | Get platform-specific posting rules and settings schema |
 | `triggerTool` | Execute platform-specific helpers (e.g., list Discord channels) |
 | `schedulePostTool` | Schedule, draft, or immediately publish posts |
+| `postsListTool` | List the organization's posts scheduled between two dates (with their current settings) |
 | `generateImageTool` | Generate AI images for posts |
 | `generateVideoOptions` | List available video generation options |
 | `videoFunctionTool` | Get video generator settings (e.g., available voices) |

--- a/mcp/tools.mdx
+++ b/mcp/tools.mdx
@@ -176,7 +176,7 @@ If validation fails, returns `{ errors: string }` with details about what went w
 
 ## postsListTool
 
-List the organization's posts scheduled between two dates, the same data as the [List Posts](/public-api/posts/list) API endpoint. Each item includes the post's current provider settings.
+List the organization's posts scheduled between two dates. It returns the same posts as the [List Posts](/public-api/posts/list) API endpoint, but with the channel details flattened into `integrationId`, `platform`, and `integrationName` fields instead of the API's nested `integration` object. Each item includes the post's current provider settings.
 
 **Parameters:**
 

--- a/mcp/tools.mdx
+++ b/mcp/tools.mdx
@@ -174,6 +174,36 @@ If validation fails, returns `{ errors: string }` with details about what went w
 
 ---
 
+## postsListTool
+
+List the organization's posts scheduled between two dates — the same data as the [List Posts](/public-api/posts/list) API endpoint. Each item includes the post's current provider settings.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `startDate` | string | Yes | UTC ISO datetime for the start of the range (e.g., `2026-07-20T00:00:00`) |
+| `endDate` | string | Yes | UTC ISO datetime for the end of the range (e.g., `2026-07-27T00:00:00`) |
+| `customer` | string | No | Group (customer) ID from `groupList` to filter channels down to a single group |
+
+**Returns:**
+
+An object with a `posts` array. Each item has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Post ID |
+| `publishDate` | string | UTC datetime the post is scheduled for |
+| `state` | string | Post state (`QUEUE`, `DRAFT`, `PUBLISHED`, or `ERROR`) |
+| `content` | string | The post content |
+| `settings` | object | The post's current provider-specific settings |
+| `group` | string | The post group ID (shared across a post and its per-channel variations) |
+| `integrationId` | string | ID of the channel the post is scheduled to |
+| `platform` | string | Platform identifier (e.g., `x`, `linkedin`, `facebook`) |
+| `integrationName` | string | Display name of the channel |
+
+---
+
 ## generateImageTool
 
 Generate an AI image to use as a post attachment.

--- a/mcp/tools.mdx
+++ b/mcp/tools.mdx
@@ -176,14 +176,14 @@ If validation fails, returns `{ errors: string }` with details about what went w
 
 ## postsListTool
 
-List the organization's posts scheduled between two dates — the same data as the [List Posts](/public-api/posts/list) API endpoint. Each item includes the post's current provider settings.
+List the organization's posts scheduled between two dates, the same data as the [List Posts](/public-api/posts/list) API endpoint. Each item includes the post's current provider settings.
 
 **Parameters:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `startDate` | string | Yes | UTC ISO datetime for the start of the range (e.g., `2026-07-20T00:00:00`) |
-| `endDate` | string | Yes | UTC ISO datetime for the end of the range (e.g., `2026-07-27T00:00:00`) |
+| `startDate` | string | Yes | UTC ISO datetime for the start of the range (e.g. `2026-07-20T00:00:00Z`) |
+| `endDate` | string | Yes | UTC ISO datetime for the end of the range (e.g. `2026-07-27T00:00:00Z`) |
 | `customer` | string | No | Group (customer) ID from `groupList` to filter channels down to a single group |
 
 **Returns:**

--- a/public-api/openapi.json
+++ b/public-api/openapi.json
@@ -2262,6 +2262,14 @@
           "content": {
             "type": "string"
           },
+          "settings": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "The post's current provider-specific settings (the same shape used when creating the post). Keys depend on the channel's platform.",
+            "example": {
+              "content_posting_method": "DIRECT_POST"
+            }
+          },
           "publishDate": {
             "type": "string",
             "format": "date-time"


### PR DESCRIPTION
Docs for the List Posts changes. Complementary to postiz-app **#1751** (`feat/list-posts-tool`).

## Changes
- **`public-api/openapi.json`** — add a `settings` field (free-form object) to the `Post` schema, so `GET /public/v1/posts` documents the provider settings now returned on every post. Additive and backward-compatible.
- **`mcp/introduction.mdx`** — add `postsListTool` to the Available Tools table; bump the tool count to **10**.
- **`mcp/tools.mdx`** — add a `## postsListTool` reference section.

## Tool-count coordination
The sibling docs PR (Update Post Settings) also adds one tool. These are stacked, so on this branch alone the count is **10**; the stacked PR bumps it to **11**. If the branches land independently, whoever merges second should reconcile the count (and the shared `mcp/*` files) — a trivial resolution.

## Verification
- `openapi.json` validated as JSON (`python3 -m json.tool`).
- Rendered locally with **Mintlify** (`mint dev`) — List Posts page and MCP pages render without errors.
- Pages **Claude-viewed** in-browser and **human-viewed**.

Related: gitroomhq/postiz-app#1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MCP documentation to reflect **10** available tools.
  * Documented a tool for listing scheduled posts within a UTC date range, with an optional filter.
  * Added details about returned post metadata and provider-specific settings.

* **API Updates**
  * Added provider-specific `settings` to the public `Post` schema, including example data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->