### PR TITLE
docs: Update Post Settings endpoint + postSettingsTool

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -147,7 +147,8 @@
               "public-api/posts/delete-by-group",
               "public-api/posts/missing-content",
               "public-api/posts/update-release-id",
-              "public-api/posts/change-status"
+              "public-api/posts/change-status",
+              "public-api/posts/settings"
             ]
           },
           {

--- a/mcp/introduction.mdx
+++ b/mcp/introduction.mdx
@@ -9,7 +9,7 @@ This means you can connect Claude, ChatGPT, Cursor, or any MCP-compatible client
 
 ## How It Works
 
-Postiz exposes an MCP server that provides **10 tools** to AI agents. The agent discovers these tools, understands their schemas, and calls them on your behalf.
+Postiz exposes an MCP server that provides **11 tools** to AI agents. The agent discovers these tools, understands their schemas, and calls them on your behalf.
 
 ```mermaid
 sequenceDiagram
@@ -35,6 +35,7 @@ sequenceDiagram
 | `triggerTool` | Execute platform-specific helpers (e.g., list Discord channels) |
 | `schedulePostTool` | Schedule, draft, or immediately publish posts |
 | `postsListTool` | List the organization's posts scheduled between two dates (with their current settings) |
+| `postSettingsTool` | Update the provider settings of a scheduled post or draft that was not published yet |
 | `generateImageTool` | Generate AI images for posts |
 | `generateVideoOptions` | List available video generation options |
 | `videoFunctionTool` | Get video generator settings (e.g., available voices) |

--- a/mcp/tools.mdx
+++ b/mcp/tools.mdx
@@ -204,6 +204,35 @@ An object with a `posts` array. Each item has:
 
 ---
 
+## postSettingsTool
+
+Update only the provider settings of a not-yet-published post (scheduled or draft). Merges the given keys into the post's existing settings — content and publish date are unchanged.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | The post ID |
+| `settings` | array | Yes | The settings keys to change (only those are updated). Get valid keys from `integrationSchema` |
+
+Each item in `settings`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Setting name |
+| `value` | any | Setting value (prefer IDs over labels when available) |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `postId` | string | The updated post ID |
+| `publishDate` | string | The post's publish date (unchanged) |
+
+If the update fails, returns `{ errors: string }` with details (e.g., post not found, already published, a comment id was passed instead of the root post, or the merged settings failed validation).
+
+---
+
 ## generateImageTool
 
 Generate an AI image to use as a post attachment.

--- a/mcp/tools.mdx
+++ b/mcp/tools.mdx
@@ -206,7 +206,7 @@ An object with a `posts` array. Each item has:
 
 ## postSettingsTool
 
-Update only the provider settings of a not-yet-published post (scheduled or draft). Merges the given keys into the post's existing settings — content and publish date are unchanged.
+Update only the provider settings of a not-yet-published post (scheduled or draft). Merges the given keys into the post's existing settings. Content and publish date are unchanged.
 
 **Parameters:**
 

--- a/public-api/openapi.json
+++ b/public-api/openapi.json
@@ -1675,6 +1675,82 @@
         }
       }
     },
+    "/posts/{id}/settings": {
+      "put": {
+        "tags": [
+          "Posts"
+        ],
+        "summary": "Update post settings",
+        "description": "Merges the given keys into the post's existing provider settings. Only the keys you pass are changed; content and publish date are untouched, so a running publishing workflow is not restarted. The merged settings are re-validated. Works only on not-yet-published posts (scheduled or draft).",
+        "operationId": "updatePostSettings",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Post ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "settings"
+                ],
+                "properties": {
+                  "settings": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Provider settings to merge into the post's existing settings. Only the keys you pass are changed; everything else stays. Keys depend on the channel's platform."
+                  }
+                }
+              },
+              "example": {
+                "settings": {
+                  "content_posting_method": "DIRECT_POST"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Post settings updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "postId": {
+                      "type": "string"
+                    },
+                    "publishDate": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "postId": "post-123",
+                  "publishDate": "2026-08-01T10:00:00"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The id belongs to a comment (pass the root post id), the post is already published or its publish time passed, or the merged settings failed validation"
+          },
+          "404": {
+            "description": "Post not found"
+          }
+        }
+      }
+    },
     "/analytics/{integration}": {
       "get": {
         "tags": [

--- a/public-api/posts/settings.mdx
+++ b/public-api/posts/settings.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Update Post Settings'
+openapi: 'PUT /posts/{id}/settings'
+---


### PR DESCRIPTION
Docs for the Update Post Settings changes. Complementary to postiz-app **#1752** (`feat/agent-update-posts`).

> **Stacked PR** — base is `feat/list-posts-docs` (#232), not `main`. Review/merge that one first; this diff shows only the update-post-settings changes on top of it.

## Changes
- **`public-api/openapi.json`** — add the `PUT /posts/{id}/settings` operation (modeled on `PUT /posts/{id}/status`): merges the given keys into a not-yet-published post's provider settings; content and publish date unchanged.
- **`public-api/posts/settings.mdx`** — new OpenAPI-backed page (the "Update Post Settings" button under Posts).
- **`docs.json`** — register the new page in the Posts nav group.
- **`mcp/introduction.mdx`** — add `postSettingsTool` to the Available Tools table; bump the tool count to **11** (10 from the stacked List Posts PR + 1 here).
- **`mcp/tools.mdx`** — add a `## postSettingsTool` reference section.

## Tool-count coordination
Count is **11** as stacked. If this lands independently of #232, reconcile the count and the shared `mcp/*` files at merge time.

## Verification
- `openapi.json` and `docs.json` validated as JSON.
- Rendered locally with **Mintlify** (`mint dev`) — the new endpoint page appears under Posts and renders (route, request body, 200 response); MCP pages render without errors.
- New/updated pages **Claude-viewed** in-browser and **human-viewed**.

Related: gitroomhq/postiz-app#1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)
