### PR TITLE
Document the DISABLE_SSRF_PROTECTION environment variable

### DIFF
--- a/configuration/reference.mdx
+++ b/configuration/reference.mdx
@@ -99,7 +99,7 @@ When truthy, the frontend skips client-side image compression on upload. Set thi
 When connecting providers that take a self-hosted URL (WordPress, Mastodon, Lemmy, Listmonk, Bluesky PDS, etc.), posting media to such providers, fetching webhooks, or handling `/public/v1/upload-from-url`, Postiz fetches the URL server-side and blocks requests that resolve to private, internal, loopback, or link-local IPs to prevent SSRF. Blocked requests surface as `fetch failed` with `Error: Blocked IP` in the backend or orchestrator logs. Set to `true` to disable the guard. Set it on both the backend and orchestrator containers.
 
 <Warning>
-This disables SSRF protection globally, not per provider. Only set it if your Postiz instance must reach those services on a trusted private network (e.g. same Docker network, VPC, or homelab LAN) **and** all users of the instance are trusted (single-tenant) — any user who can submit a URL can make the server fetch internal services. Prefer fixing DNS/routing so the hostname resolves to a reachable address.
+This disables SSRF protection globally, not per provider. Only set it if your Postiz instance must reach those services on a trusted private network (e.g. same Docker network, VPC, or homelab LAN) **and** all users of the instance are trusted (single-tenant). Any user who can submit a URL can make the server fetch internal services. Prefer fixing DNS/routing so the hostname resolves to a reachable address.
 </Warning>
 
 ### `NOT_SECURED`

--- a/configuration/reference.mdx
+++ b/configuration/reference.mdx
@@ -99,7 +99,7 @@ When truthy, the frontend skips client-side image compression on upload. Set thi
 When connecting providers that take a self-hosted URL (WordPress, Mastodon, Lemmy, Listmonk, Bluesky PDS, etc.), posting media to such providers, fetching webhooks, or handling `/public/v1/upload-from-url`, Postiz fetches the URL server-side and blocks requests that resolve to private, internal, loopback, or link-local IPs to prevent SSRF. Blocked requests surface as `fetch failed` with `Error: Blocked IP` in the backend or orchestrator logs. Set to `true` to disable the guard. Set it on both the backend and orchestrator containers.
 
 <Warning>
-This disables SSRF protection globally, not per provider. Only set it if your Postiz instance must reach those services on a trusted private network (e.g. same Docker network, VPC, or homelab LAN).
+This disables SSRF protection globally, not per provider. Only set it if your Postiz instance must reach those services on a trusted private network (e.g. same Docker network, VPC, or homelab LAN) **and** all users of the instance are trusted (single-tenant) — any user who can submit a URL can make the server fetch internal services. Prefer fixing DNS/routing so the hostname resolves to a reachable address.
 </Warning>
 
 ### `NOT_SECURED`

--- a/configuration/reference.mdx
+++ b/configuration/reference.mdx
@@ -94,6 +94,14 @@ Switches the frontend between routes available to the open-source build (`/launc
 
 When truthy, the frontend skips client-side image compression on upload. Set this if you need pixel-exact originals at the cost of larger uploads.
 
+### `DISABLE_SSRF_PROTECTION`
+
+When connecting providers that take a self-hosted URL (WordPress, Mastodon, Lemmy, Listmonk, Bluesky PDS, etc.), posting media to such providers, fetching webhooks, or handling `/public/v1/upload-from-url`, Postiz fetches the URL server-side and blocks requests that resolve to private, internal, loopback, or link-local IPs to prevent SSRF. Blocked requests surface as `fetch failed` with `Error: Blocked IP` in the backend or orchestrator logs. Set to `true` to disable the guard. Set it on both the backend and orchestrator containers.
+
+<Warning>
+This disables SSRF protection globally, not per provider. Only set it if your Postiz instance must reach those services on a trusted private network (e.g. same Docker network, VPC, or homelab LAN).
+</Warning>
+
 ### `NOT_SECURED`
 
 <Warning>

--- a/providers/mastodon.mdx
+++ b/providers/mastodon.mdx
@@ -73,13 +73,13 @@ The Postiz backend needs network access to reach your Mastodon instance. If the 
 1. From inside the backend container, run `curl -I https://your-instance.example.com/`. If that fails, fix DNS/egress before retrying.
 2. If you're behind a corporate proxy, set `HTTPS_PROXY` on the backend.
 3. Confirm `MASTODON_URL` exactly matches your instance — protocol included, no trailing slash issues.
-4. If the logs show `Error: Blocked IP`, your instance hostname resolves to a private IP and the SSRF guard rejected it — see the media troubleshooting below.
+4. If the logs show `Error: Blocked IP`, your instance hostname resolves to a private IP and the SSRF guard rejected it, see the media troubleshooting below.
 
 ### "fetch failed" when posting with media (text posts work)
 
 Text posts publish fine, but posts with images fail with `fetch failed`, and the orchestrator logs show `Error: Blocked IP`.
 
-**Cause:** before uploading media to your instance, Postiz downloads it from its own public media URL (e.g. `https://postiz.example.com/uploads/...`). If that hostname resolves to a private IP from inside the container — common behind home reverse proxies like Caddy, split DNS, or hairpin NAT — the SSRF guard blocks the fetch.
+**Cause:** before uploading media to your instance, Postiz downloads it from its own public media URL (e.g. `https://postiz.example.com/uploads/...`). If that hostname resolves to a private IP from inside the container, common behind home reverse proxies like Caddy, split DNS, or hairpin NAT, the SSRF guard blocks the fetch.
 
 **Fix**
 
@@ -88,5 +88,5 @@ Text posts publish fine, but posts with images fail with `fetch failed`, and the
 
 Alternatively, fix resolution instead: make the media hostname resolve to a reachable address from inside the container (e.g. a Docker DNS alias or split-horizon DNS entry) and keep the protection on.
 
-Note this disables SSRF protection globally — only do it when Postiz runs on a trusted private network. See [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
+Note this disables SSRF protection globally, only do it when Postiz runs on a trusted private network. See [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 

--- a/providers/mastodon.mdx
+++ b/providers/mastodon.mdx
@@ -73,4 +73,18 @@ The Postiz backend needs network access to reach your Mastodon instance. If the 
 1. From inside the backend container, run `curl -I https://your-instance.example.com/`. If that fails, fix DNS/egress before retrying.
 2. If you're behind a corporate proxy, set `HTTPS_PROXY` on the backend.
 3. Confirm `MASTODON_URL` exactly matches your instance — protocol included, no trailing slash issues.
+4. If the logs show `Error: Blocked IP`, your instance hostname resolves to a private IP and the SSRF guard rejected it — see the media troubleshooting below.
+
+### "fetch failed" when posting with media (text posts work)
+
+Text posts publish fine, but posts with images fail with `fetch failed`, and the orchestrator logs show `Error: Blocked IP`.
+
+**Cause:** before uploading media to your instance, Postiz downloads it from its own public media URL (e.g. `https://postiz.example.com/uploads/...`). If that hostname resolves to a private IP from inside the container — common behind home reverse proxies like Caddy, split DNS, or hairpin NAT — the SSRF guard blocks the fetch.
+
+**Fix**
+
+1. Set `DISABLE_SSRF_PROTECTION=true` on the backend and orchestrator containers.
+2. Restart the containers.
+
+Note this disables SSRF protection globally — only do it when Postiz runs on a trusted private network. See [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 

--- a/providers/mastodon.mdx
+++ b/providers/mastodon.mdx
@@ -86,5 +86,7 @@ Text posts publish fine, but posts with images fail with `fetch failed`, and the
 1. Set `DISABLE_SSRF_PROTECTION=true` on the backend and orchestrator containers.
 2. Restart the containers.
 
+Alternatively, fix resolution instead: make the media hostname resolve to a reachable address from inside the container (e.g. a Docker DNS alias or split-horizon DNS entry) and keep the protection on.
+
 Note this disables SSRF protection globally — only do it when Postiz runs on a trusted private network. See [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 

--- a/public-api/uploads/upload-from-url.mdx
+++ b/public-api/uploads/upload-from-url.mdx
@@ -9,7 +9,7 @@ Fetch a remote URL and store the result as a Postiz media asset. Useful when you
 
 - Must be reachable from the Postiz backend (publicly resolvable HTTPS, no auth required).
 - Detected MIME type must be in the allowlist documented on [Upload File](/public-api/uploads/upload-file).
-- Postiz performs an [SSRF-safe fetch](https://github.com/nodejs/undici) — private IP ranges, link-local addresses, and `localhost` are rejected. Self-hosted deployments on a trusted private network can disable this with [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
+- Postiz performs an [SSRF-safe fetch](https://github.com/nodejs/undici), private IP ranges, link-local addresses, and `localhost` are rejected. Self-hosted deployments on a trusted private network can disable this with [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 
 ## Example
 

--- a/public-api/uploads/upload-from-url.mdx
+++ b/public-api/uploads/upload-from-url.mdx
@@ -9,7 +9,7 @@ Fetch a remote URL and store the result as a Postiz media asset. Useful when you
 
 - Must be reachable from the Postiz backend (publicly resolvable HTTPS, no auth required).
 - Detected MIME type must be in the allowlist documented on [Upload File](/public-api/uploads/upload-file).
-- Postiz performs an [SSRF-safe fetch](https://github.com/nodejs/undici) — private IP ranges, link-local addresses, and `localhost` are rejected.
+- Postiz performs an [SSRF-safe fetch](https://github.com/nodejs/undici) — private IP ranges, link-local addresses, and `localhost` are rejected. Self-hosted deployments on a trusted private network can disable this with [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 
 ## Example
 

--- a/troubleshooting/oauth-connect.mdx
+++ b/troubleshooting/oauth-connect.mdx
@@ -74,6 +74,9 @@ connection.
   reach (firewall, missing DNS).
 - GMB metrics endpoint blocked by egress filtering.
 - A reverse proxy in front of Postiz is rewriting the outbound request.
+- The logs show `Error: Blocked IP` — the URL resolved to a private IP
+  and Postiz's SSRF guard rejected it. For trusted private networks, see
+  [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 
 **Fix**
 

--- a/troubleshooting/oauth-connect.mdx
+++ b/troubleshooting/oauth-connect.mdx
@@ -74,7 +74,7 @@ connection.
   reach (firewall, missing DNS).
 - GMB metrics endpoint blocked by egress filtering.
 - A reverse proxy in front of Postiz is rewriting the outbound request.
-- The logs show `Error: Blocked IP` — the URL resolved to a private IP
+- The logs show `Error: Blocked IP`, the URL resolved to a private IP
   and Postiz's SSRF guard rejected it. For trusted private networks, see
   [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 

--- a/troubleshooting/uploads.mdx
+++ b/troubleshooting/uploads.mdx
@@ -60,7 +60,10 @@ or sits behind authentication, the upload fails.
 
 - Make sure the source URL is publicly reachable HTTPS, with no auth.
 - Don't link to private S3 URLs, signed URLs that have expired, or
-  intranet hosts.
+  intranet hosts. URLs resolving to private or internal IPs are blocked
+  by design (`Error: Blocked IP` in the logs); for trusted-network
+  deployments, see
+  [`DISABLE_SSRF_PROTECTION`](/configuration/reference#disable_ssrf_protection).
 - If the source is consistently slow, pre-download the file locally and
   use the multipart `/upload` endpoint instead.
 


### PR DESCRIPTION
Postiz's SSRF guard (ssrf.safe.dispatcher.ts) blocks server-side fetches that resolve to private/loopback/link-local IPs, surfacing as "fetch failed" with "Error: Blocked IP" in backend/orchestrator logs. The DISABLE_SSRF_PROTECTION escape hatch was documented only in the app repo's .env.example, so self-hosters hitting it couldn't find the fix on docs.postiz.com.

Customer context: a self-hoster running Postiz behind Caddy at home reported Mastodon text posts working but image posts failing with "fetch failed". The orchestrator log showed "Blocked IP" from the SSRF dispatcher inside MastodonProvider.uploadFile — Postiz downloads its own media URL before re-uploading to the instance, and that hostname resolved to a private IP from inside the container (hairpin NAT / split DNS behind the home reverse proxy). The Mastodon page's existing "fetch failed" troubleshooting blurb didn't cover this case.

Changes:
- configuration/reference.mdx: canonical DISABLE_SSRF_PROTECTION entry under Application behaviour, with a Warning that it disables SSRF protection globally and should only be set on trusted private networks.
- providers/mastodon.mdx: new troubleshooting subsection for the media-posting case (text posts work, image posts fail), plus a Blocked IP pointer in the connect section.
- troubleshooting/oauth-connect.mdx: Blocked IP bullet under "fetch failed" on provider connect.
- troubleshooting/uploads.mdx: note that private/internal source URLs are blocked by design.
- public-api/uploads/upload-from-url.mdx: pointer next to the existing SSRF-safe fetch mention.

All pages verified rendering locally with mint dev, including the /configuration/reference#disable_ssrf_protection anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the SSRF protection guidance to clarify that disabling it requires a trusted, single-tenant setup.
  * Updated upload-from-URL requirements to note SSRF-safe fetching rules (private ranges, link-local, and `localhost`) and the trusted-network escape hatch.
  * Enhanced troubleshooting for “fetch failed” issues across provider connections and media uploads, including guidance to fix DNS/resolution while keeping protection enabled.
  * Documented blocked-IP behavior, including the `Error: Blocked IP` log entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->